### PR TITLE
fix(menubar): fix setting focus on a menu item that doesn't exist

### DIFF
--- a/src/menubar.ts
+++ b/src/menubar.ts
@@ -366,7 +366,7 @@ export class Menubar {
 
 				if (isFocused) {
 					if (this.focusedMenu) {
-						this.menuItems[this.focusedMenu.index].buttonElement.blur();
+						this.menuItems[this.focusedMenu.index]?.buttonElement.blur();
 					}
 
 					this.focusedMenu = undefined;
@@ -389,7 +389,7 @@ export class Menubar {
 				}
 
 				if (this.focusedMenu) {
-					this.menuItems[this.focusedMenu.index].buttonElement.focus();
+					this.menuItems[this.focusedMenu.index]?.buttonElement.focus();
 				}
 
 				break;


### PR DESCRIPTION
When a menubar has been updated, changed or items removed, its possible to still try reference the focused menu item. This fixes an undefined error that occurs when updating the focused state.